### PR TITLE
Fix issue with automatic conversion of invalid dates in leave command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -178,19 +180,44 @@ public class ParserUtil {
         requireNonNull(leaveEnd);
         requireNonNull(reason);
 
-        if (!Leave.isValidDate(leaveStart) || !Leave.isValidDate(leaveEnd)) {
-            throw new ParseException(Leave.DATE_CONSTRAINTS);
+        // Check start date
+        try {
+            LocalDate startDate = LocalDate.parse(leaveStart, Leave.DATE_FORMATER);
+            validateYear(startDate, "Start date: ");
+        } catch (DateTimeParseException e) {
+            throw new ParseException(String.format("Invalid start date: %s.\n%s",
+                    leaveStart, Leave.DATE_CONSTRAINTS));
         }
 
+        // Check end date
+        try {
+            LocalDate startDate = LocalDate.parse(leaveEnd, Leave.DATE_FORMATER);
+            validateYear(startDate, "End date: ");
+        } catch (DateTimeParseException e) {
+            throw new ParseException(String.format("Invalid end date: %s.\n%s",
+                    leaveEnd, Leave.DATE_CONSTRAINTS));
+        }
+
+        // Check reason
         if (!Leave.isValidReason(reason)) {
             throw new ParseException(Leave.REASON_CONSTRAINTS);
         }
 
-        if (!Leave.isValidLeave(leaveStart, leaveEnd, reason)) {
-            throw new ParseException(Leave.DATE_CONSTRAINTS);
+        // Check if start date is before or equal to end date
+        if (!Leave.isValidOrder(leaveStart, leaveEnd)) {
+            throw new ParseException(String.format("Invalid date order.\n%s", Leave.DATE_CONSTRAINTS));
         }
 
         return new Leave(leaveStart, leaveEnd, reason);
+    }
+
+    // Helper method for parseLeave to check if a date is within the valid range
+    private static void validateYear(LocalDate date, String fieldName) throws ParseException {
+        int year = date.getYear();
+        if (year < Leave.MIN_YEAR || year > Leave.MAX_YEAR) {
+            throw new ParseException(String.format("%s: Year must be between %d and %d.\n%s",
+                    fieldName, Leave.MIN_YEAR, Leave.MAX_YEAR, Leave.DATE_CONSTRAINTS));
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/leave/Leave.java
+++ b/src/main/java/seedu/address/model/leave/Leave.java
@@ -5,18 +5,31 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 
 /**
  * Represents a Leave in the address book.
  */
 public class Leave {
+    public static final int MIN_YEAR = 1900;
+    public static final int MAX_YEAR = 2100;
+
+    public static final String DATE_CONSTRAINTS =
+            "Please ensure your dates meet all these requirements:\n"
+                    + "1. FORMAT: Must use yyyy-MM-dd (e.g., 2025-02-28)\n"
+                    + "2. YEAR RANGE: Must be between " + MIN_YEAR + " and " + MAX_YEAR + "\n"
+                    + "3. VALID DATE: Must be a real calendar date\n"
+                    + "   - February has 28 days (29 in leap years)\n"
+                    + "   - April, June, September, November have 30 days\n"
+                    + "   - Other months have 31 days\n"
+                    + "4. DATE ORDER: Start date must be on or before end date";
+
     public static final String REASON_CONSTRAINTS = "Reason should not be empty.";
-    public static final String DATE_CONSTRAINTS = "Provide valid dates in the format of yyyy-MM-dd.\n"
-            + "Start date >= end date.";
-    public static final String MESSAGE_CONSTRAINTS = "Leave dates should be in the format of yyyy-MM-dd.\n"
-            + "Start date should be before end date.\n"
-            + "Reason should not be empty.";
-    private static final DateTimeFormatter DateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+
+    public static final DateTimeFormatter DATE_FORMATER = DateTimeFormatter
+            .ofPattern("uuuu-MM-dd")
+            .withResolverStyle(ResolverStyle.STRICT);
 
     private final LocalDate startDate;
     private final LocalDate endDate;
@@ -34,25 +47,19 @@ public class Leave {
         requireNonNull(endDate);
         requireNonNull(reason);
         checkArgument(isValidLeave(startDate, endDate, reason), DATE_CONSTRAINTS);
-        this.startDate = LocalDate.parse(startDate, DateFormatter);
-        this.endDate = LocalDate.parse(endDate, DateFormatter);
+        this.startDate = LocalDate.parse(startDate, DATE_FORMATER);
+        this.endDate = LocalDate.parse(endDate, DATE_FORMATER);
         this.reason = reason;
     }
 
     /**
      * Returns true if a given string is a valid leave.
      */
-    public static boolean isValidLeave(String startDateString, String endDateString, String reason) {
-        if (!isValidDate(startDateString) || !isValidDate(endDateString)) {
-            return false;
-        }
-
-        if (!isValidReason(reason)) {
-            return false;
-        }
-
-        // startDate <= endDate
-        return !LocalDate.parse(startDateString, DateFormatter).isAfter(LocalDate.parse(endDateString, DateFormatter));
+    public static boolean isValidLeave(String startDate, String endDate, String reason) {
+        return isValidDate(startDate)
+                && isValidDate(endDate)
+                && isValidReason(reason)
+                && isValidOrder(startDate, endDate);
     }
 
     /**
@@ -60,11 +67,13 @@ public class Leave {
      */
     public static boolean isValidDate(String date) {
         try {
-            LocalDate.parse(date, DateFormatter);
+            LocalDate parsedDate = LocalDate.parse(date, DATE_FORMATER);
+            int year = parsedDate.getYear();
+
+            return year >= MIN_YEAR && year <= MAX_YEAR;
         } catch (Exception e) {
             return false;
         }
-        return true;
     }
 
     /**
@@ -74,6 +83,14 @@ public class Leave {
     public static boolean isValidReason(String reason) {
         // Reason should not be empty or null
         return reason != null && !reason.isEmpty();
+    }
+
+    /**
+     * Returns true if the start date is before or equal to the end date.
+     */
+    public static boolean isValidOrder(String startDate, String endDate) {
+        // startDate <= endDate
+        return !LocalDate.parse(startDate, DATE_FORMATER).isAfter(LocalDate.parse(endDate, DATE_FORMATER));
     }
 
     /**
@@ -98,11 +115,11 @@ public class Leave {
     }
 
     public String getFormattedStartDate() {
-        return startDate.format(DateTimeFormatter.ofPattern("dd MMM yyyy"));
+        return startDate.format(DateTimeFormatter.ofPattern("dd MMM uuuu"));
     }
 
     public String getFormattedEndDate() {
-        return endDate.format(DateTimeFormatter.ofPattern("dd MMM yyyy"));
+        return endDate.format(DateTimeFormatter.ofPattern("dd MMM uuuu"));
     }
 
     @Override
@@ -127,6 +144,6 @@ public class Leave {
 
     @Override
     public String toString() {
-        return String.format("%s to %s (%s)", startDate.format(DateFormatter), endDate.format(DateFormatter), reason);
+        return String.format("%s to %s (%s)", startDate.format(DATE_FORMATER), endDate.format(DATE_FORMATER), reason);
     }
 }

--- a/src/main/java/seedu/address/model/leave/Leave.java
+++ b/src/main/java/seedu/address/model/leave/Leave.java
@@ -17,7 +17,7 @@ public class Leave {
     public static final String DATE_CONSTRAINTS =
             "Please ensure your dates meet all these requirements:\n"
                     + "1. FORMAT: Must use yyyy-MM-dd (e.g., 2025-02-28)\n"
-                    + "2. YEAR RANGE: Must be between " + MIN_YEAR + " and " + MAX_YEAR + "\n"
+                    + "2. YEAR RANGE: Must be between " + MIN_YEAR + " and " + MAX_YEAR + " (inclusive)\n"
                     + "3. VALID DATE: Must be a real calendar date\n"
                     + "   - February has 28 days (29 in leap years)\n"
                     + "   - April, June, September, November have 30 days\n"

--- a/src/test/java/seedu/address/model/leave/LeaveTest.java
+++ b/src/test/java/seedu/address/model/leave/LeaveTest.java
@@ -112,8 +112,27 @@ public class LeaveTest {
     }
 
     @Test
-    public void testInvalidDate() {
+    public void testDateValidation() {
         assertFalse(Leave.isValidDate("2025-02-30")); // February 30th should be invalid
         assertFalse(Leave.isValidDate("2025-04-31")); // April 31st should be invalid
+        assertFalse(Leave.isValidDate("2025-14-01")); // Invalid month
+        assertFalse(Leave.isValidDate("abcd-ef-gh")); // Invalid input
+        assertFalse(Leave.isValidDate("01-01-2025")); // Invalid format
+        assertFalse(Leave.isValidDate(null)); // Null input
+        assertFalse(Leave.isValidDate("")); // Empty string
+        assertTrue(Leave.isValidDate("2025-02-28")); // Valid date
+
+        // Leap year - If a year is fully divisible by 4, it is a leap year, unless it is also divisible by 100.
+        // e.g. 1600, 2000, 2400 are leap years, but 1700, 1800, 1900 are not.
+
+        assertFalse(Leave.isValidDate("1900-02-29")); // Invalid leap year
+        assertTrue(Leave.isValidDate("2000-02-29")); // Valid leap year
+
+        // Test for years outside the valid range
+        assertFalse(Leave.isValidDate("1899-12-30")); // Invalid date before MIN_YEAR
+        assertTrue(Leave.isValidDate("1900-01-01")); // Valid date on MIN_YEAR
+
+        assertFalse(Leave.isValidDate("2101-01-01")); // Invalid date after MAX_YEAR
+        assertTrue(Leave.isValidDate("2100-12-30")); // Valid date on MAX_YEAR
     }
 }

--- a/src/test/java/seedu/address/model/leave/LeaveTest.java
+++ b/src/test/java/seedu/address/model/leave/LeaveTest.java
@@ -32,7 +32,6 @@ public class LeaveTest {
     private static final String OVERLAP_END_LATE = "2025-03-17";
     private static final String NON_OVERLAP_START = "2025-03-05";
     private static final String NON_OVERLAP_END = "2025-03-08";
-    private static final String SAME_AS_START_DATE = "2025-03-10"; // Edge case
 
     @Test
     public void constructor_nullArguments_throwsNullPointerException() {
@@ -110,5 +109,11 @@ public class LeaveTest {
         Leave leave = new Leave(VALID_START_DATE, VALID_END_DATE, VALID_REASON);
         assertEquals(VALID_FORMATTED_START_DATE, leave.getFormattedStartDate());
         assertEquals(VALID_FORMATTED_END_DATE, leave.getFormattedEndDate());
+    }
+
+    @Test
+    public void testInvalidDate() {
+        assertFalse(Leave.isValidDate("2025-02-30")); // February 30th should be invalid
+        assertFalse(Leave.isValidDate("2025-04-31")); // April 31st should be invalid
     }
 }


### PR DESCRIPTION
The DateFormatter previously defaulted to ResolverStyle.SMART, which allowed invalid dates to automatically convert to valid ones.

Changes made:

- Changed ResolverStyle from SMART to STRICT to enforce stricter date validation. (closes #78)
- Improved error messages to provide clearer feedback when invalid dates are detected.
- Added constraints on year values to ensure they remain within a reasonable range.
- Added test cases to check for invalid dates in a month.

**You might have to delete the previous data file "addressbook.json" to reset the addressbook as it will fail to load invalid dates.**