### PR TITLE
Fix bugs and edit UG for 'edit' command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -411,6 +411,10 @@ edit INDEX [/name NAME] [/nric NRIC] [/phone PHONE] [/email EMAIL] [/address ADD
 - The index must be a positive integer 1, 2, 3, …​
 - Any parameters specified of the person  will be edited if format is valid
 
+**Behaviours:**
+- If there are any duplicate fields e.g. `edit 1 /name hans /name bo` then the last duplicate will take effect i.e.
+(name will be edited to 'bo'). All other duplicates will be ignored.
+
 **Examples:**
 - Edit the name of the **1st** employee to be `Robert Lee`:
 ```properties

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -39,14 +39,17 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         String preamble = argMultimap.getPreamble();
         if (preamble.isEmpty()) {
-            throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
 
         Index index;
 
         try {
-            int parsedIndex = Integer.parseInt(preamble.split(" ")[0]);
+            String[] PreamableList = preamble.split(" ");
+            if (PreamableList.length > 1) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+            }
+            int parsedIndex = Integer.parseInt(PreamableList[0]);
             if (parsedIndex == 0) {
                 throw new ParseException(MESSAGE_INDEX_ZERO);
             }


### PR DESCRIPTION
- Added 'Behaviours' under edit command in UG (closes #130)
- Fixed bug where invalid format text after index but before valid prefix is uncaught e.g. `edit 1 qwerty /name john`