### PR TITLE
Fix UI panel behavior for attendance/clear/delete commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -18,6 +18,6 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_SUCCESS, false, false, true);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -23,14 +23,18 @@ public class CommandResult {
     /** The person to view for view command (optional). */
     private final Person personToView;
 
+    /** The details panel should be cleared. */
+    private final boolean clearDetailsPanel;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean clearDetailsPanel) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
         this.personToView = null;
+        this.clearDetailsPanel = clearDetailsPanel;
     }
 
     /**
@@ -38,18 +42,27 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+        this(feedbackToUser, false, false, false);
     }
 
     /**
      * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
      * and {@code personToView} for the view command.
      */
-    public CommandResult(String feedbackToUser, Person personToView) {
+    public CommandResult(String feedbackToUser, Person personToView, boolean clearDetailsPanel) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = false;
         this.exit = false;
         this.personToView = requireNonNull(personToView);
+        this.clearDetailsPanel = clearDetailsPanel;
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
+     * and {@code personToView} for the view command, with default clearDetailsPanel value.
+     */
+    public CommandResult(String feedbackToUser, Person personToView) {
+        this(feedbackToUser, personToView, false);
     }
 
     public String getFeedbackToUser() {
@@ -68,6 +81,10 @@ public class CommandResult {
         return personToView;
     }
 
+    public boolean isClearDetailsPanel() {
+        return clearDetailsPanel;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -83,7 +100,8 @@ public class CommandResult {
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
                 && exit == otherCommandResult.exit
-                && Objects.equals(personToView, otherCommandResult.personToView);
+                && Objects.equals(personToView, otherCommandResult.personToView)
+                && clearDetailsPanel == otherCommandResult.clearDetailsPanel;
     }
 
     @Override
@@ -98,6 +116,7 @@ public class CommandResult {
                 .add("showHelp", showHelp)
                 .add("exit", exit)
                 .add("personToView", personToView)
+                .add("clearDetailsPanel", clearDetailsPanel)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -42,7 +42,8 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)),
+                personToDelete, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -169,6 +169,16 @@ public class MainWindow extends UiPart<Stage> {
         }
     }
 
+    private void handleClearDetailsPanel(CommandResult commandResult) {
+        if (!commandResult.isClearDetailsPanel()) {
+            return;
+        }
+        Person target = commandResult.getPersonToView();
+        if (target == null || personDetailsPanel.isShowing(target)) {
+            personDetailsPanel.clear();
+        }
+    }
+
     /**
      * Opens the help window or focuses on it if it's already opened.
      */
@@ -220,9 +230,15 @@ public class MainWindow extends UiPart<Stage> {
                 rightPane.getChildren().add(personDetailsPanel.getRoot());
             }
 
-            // If the command result contains a person, update the details panel
-            if (commandResult.getPersonToView() != null) {
-                personDetailsPanel.setPerson(commandResult.getPersonToView());
+            if (commandResult.isClearDetailsPanel()) {
+                handleClearDetailsPanel(commandResult);
+            } else {
+                // If the command result contains a person, update the details panel
+                if (commandResult.getPersonToView() != null) {
+                    personDetailsPanel.setPerson(commandResult.getPersonToView());
+                } else {
+                    personDetailsPanel.refresh();
+                }
             }
 
             logger.info("Result: " + commandResult.getFeedbackToUser());


### PR DESCRIPTION
Changes made:

- Added `clearDetailsPanel` flag to `CommandResult.java` 
- Added `handleClearDetails()` method and updated logic using `PersonDetailsPanel.java`'s helper methods in `MainWindow.java`. 

  - `attendance`: Now refreshes UI while maintaining current view (fixes #152)
  - `delete`: Clears panel only if person being deleted is being displayed on the panel. (fixes #155)
  - `clear`: Always clears panel (fixes #155)